### PR TITLE
Combined Smoothing Floats and Local/Remote Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,11 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+**/VRCSDK
+**/Library
+**/ProjectSettings
+*.csproj
+**/Temp
+*.sln
+**/VRCFaceTracking

--- a/.gitignore
+++ b/.gitignore
@@ -368,4 +368,4 @@ FodyWeavers.xsd
 *.csproj
 **/Temp
 *.sln
-**/VRCFaceTracking
+**/OSCmooth/Generated

--- a/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
@@ -33,7 +33,7 @@ namespace OSCTools.OSCmooth.Animation
 
             AnimatorState[] state = new AnimatorState[2];
             state[0] = animLayer.stateMachine.AddState("OSCmooth_Local", new Vector3(30, 170, 0));
-            state[1] = animLayer.stateMachine.AddState("OSCmooth_Net", new Vector3(30, 170 + 60, 0));
+            state[1] = animLayer.stateMachine.AddState("OSCmooth_Remote", new Vector3(30, 170 + 60, 0));
 
             var toRemoteState = state[0].AddTransition(state[1]);
             var toLocalState = state[1].AddTransition(state[0]);
@@ -77,14 +77,14 @@ namespace OSCTools.OSCmooth.Animation
                 localChildMotion.Add(new ChildMotion 
                 {
                     directBlendParameter = "1Set",
-                    motion = AnimUtil.CreateSmoothingBlendTree(animatorController, animLayer.stateMachine, smoothLayer.localSmoothness, smoothLayer.paramName),
+                    motion = AnimUtil.CreateSmoothingBlendTree(animatorController, animLayer.stateMachine, smoothLayer.localSmoothness, smoothLayer.paramName, smoothLayer.smoothName, "Local"),
                     timeScale = 1
                 });
 
                 remoteChildMotion.Add(new ChildMotion
                 {
                     directBlendParameter = "1Set",
-                    motion = AnimUtil.CreateSmoothingBlendTree(animatorController, animLayer.stateMachine, smoothLayer.remoteSmoothness, smoothLayer.paramName),
+                    motion = AnimUtil.CreateSmoothingBlendTree(animatorController, animLayer.stateMachine, smoothLayer.remoteSmoothness, smoothLayer.paramName, smoothLayer.smoothName, "Remote"),
                     timeScale = 1,
                 });
             }

--- a/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
@@ -40,10 +40,10 @@ namespace OSCTools.OSCmooth.Animation
             toRemoteState.duration = 0;
             toLocalState.duration = 0;
 
-            ParameterUtil.CheckAndCreateParameter("isLocal", animatorController, AnimatorControllerParameterType.Bool);
+            ParameterUtil.CheckAndCreateParameter("IsLocal", animatorController, AnimatorControllerParameterType.Bool);
 
-            toRemoteState.AddCondition(AnimatorConditionMode.IfNot, 0, "isLocal");
-            toLocalState.AddCondition(AnimatorConditionMode.If, 0, "isLocal");
+            toRemoteState.AddCondition(AnimatorConditionMode.IfNot, 0, "IsLocal");
+            toLocalState.AddCondition(AnimatorConditionMode.If, 0, "IsLocal");
 
             var basisLocalBlendTree = new BlendTree()
             {
@@ -84,7 +84,7 @@ namespace OSCTools.OSCmooth.Animation
                 remoteChildMotion.Add(new ChildMotion
                 {
                     directBlendParameter = "1Set",
-                    motion = AnimUtil.CreateSmoothingBlendTree(animatorController, animLayer.stateMachine, smoothLayer.localSmoothness, smoothLayer.paramName),
+                    motion = AnimUtil.CreateSmoothingBlendTree(animatorController, animLayer.stateMachine, smoothLayer.remoteSmoothness, smoothLayer.paramName),
                     timeScale = 1,
                 });
             }

--- a/Assets/OSCmooth/Editor/OSCmoothType.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothType.cs
@@ -10,6 +10,7 @@ namespace OSCTools.OSCmooth.Types
         public float localSmoothness;
         public float remoteSmoothness;
         public string paramName;
+        public string smoothName;
 
         // This setting renames any instance of the base parameter
         // in the animator with the Proxy parameter. This is intended
@@ -27,6 +28,7 @@ namespace OSCTools.OSCmooth.Types
             localSmoothness = 0.5f;
             remoteSmoothness = 0.9f;
             paramName = "New Parameter";
+            smoothName = "OSCmoother";
             isVisible = false;
             flipInputOutput = false;
         }

--- a/Assets/OSCmooth/Editor/OSCmoothUtil.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothUtil.cs
@@ -44,16 +44,16 @@ namespace OSCTools.OSCmooth.Util
             _animationClip1.SetCurve("", typeof(Animator), paramName, _curve1);
             _animationClip2.SetCurve("", typeof(Animator), paramName, _curve2);
 
-            if (!Directory.Exists("Assets/VRCFaceTracking/Generated/Anims/"))
+            if (!Directory.Exists("Assets/OSCmooth/Generated/Anims/"))
             {
-                Directory.CreateDirectory("Assets/VRCFaceTracking/Generated/Anims/");
+                Directory.CreateDirectory("Assets/OSCmooth/Generated/Anims/");
             }
 
             string[] guid = (AssetDatabase.FindAssets(paramName + initThreshold + "Smoother.anim"));
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip1, "Assets/VRCFaceTracking/Generated/Anims/" + paramName + initThreshold + smoothSuffix + ".anim");
+                AssetDatabase.CreateAsset(_animationClip1, "Assets/OSCmooth/Generated/Anims/" + paramName + initThreshold + smoothSuffix + ".anim");
                 AssetDatabase.SaveAssets();
             }
 
@@ -66,7 +66,7 @@ namespace OSCTools.OSCmooth.Util
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip2, "Assets/VRCFaceTracking/Generated/Anims/" + paramName + finalThreshold + smoothSuffix + ".anim");
+                AssetDatabase.CreateAsset(_animationClip2, "Assets/OSCmooth/Generated/Anims/" + paramName + finalThreshold + smoothSuffix + ".anim");
                 AssetDatabase.SaveAssets();
             }
 

--- a/Assets/OSCmooth/Editor/OSCmoothUtil.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothUtil.cs
@@ -33,7 +33,7 @@ namespace OSCTools.OSCmooth.Util
             return layer;
         }
 
-        public static AnimationClip[] CreateFloatSmootherAnimation(string paramName, string smoothSuffix, float initThreshold = 0, float finalThreshold = 1)
+        public static AnimationClip[] CreateFloatSmootherAnimation(string paramName, string smoothnessSuffix, float initThreshold = 0, float finalThreshold = 1)
         {
             AnimationClip _animationClip1 = new AnimationClip();
             AnimationClip _animationClip2 = new AnimationClip();
@@ -53,7 +53,7 @@ namespace OSCTools.OSCmooth.Util
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip1, "Assets/OSCmooth/Generated/Anims/" + paramName + initThreshold + smoothSuffix + ".anim");
+                AssetDatabase.CreateAsset(_animationClip1, "Assets/OSCmooth/Generated/Anims/" + paramName + initThreshold + smoothnessSuffix + ".anim");
                 AssetDatabase.SaveAssets();
             }
 
@@ -62,11 +62,11 @@ namespace OSCTools.OSCmooth.Util
                 _animationClip1 = (AnimationClip)AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath(guid[0]), typeof(AnimationClip));
             }
 
-            guid = (AssetDatabase.FindAssets(paramName + finalThreshold + smoothSuffix + ".anim"));
+            guid = (AssetDatabase.FindAssets(paramName + finalThreshold + smoothnessSuffix + ".anim"));
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip2, "Assets/OSCmooth/Generated/Anims/" + paramName + finalThreshold + smoothSuffix + ".anim");
+                AssetDatabase.CreateAsset(_animationClip2, "Assets/OSCmooth/Generated/Anims/" + paramName + finalThreshold + smoothnessSuffix + ".anim");
                 AssetDatabase.SaveAssets();
             }
 
@@ -78,9 +78,9 @@ namespace OSCTools.OSCmooth.Util
             return new AnimationClip[] { _animationClip1, _animationClip2 };
         }
 
-        public static BlendTree CreateSmoothingBlendTree(AnimatorController animatorController, AnimatorStateMachine stateMachine, float smoothness, string paramName, string smoothnessSuffix = "Smoother", string proxySuffix = "Proxy")
+        public static BlendTree CreateSmoothingBlendTree(AnimatorController animatorController, AnimatorStateMachine stateMachine, float smoothness, string paramName, string smootherName, string netState = "Local", string smoothnessSuffix = "Smoother", string proxySuffix = "Proxy")
         {
-            AnimatorControllerParameter smootherParam = ParameterUtil.CheckAndCreateParameter(paramName + smoothnessSuffix, animatorController, AnimatorControllerParameterType.Float, smoothness);
+            AnimatorControllerParameter smootherParam = ParameterUtil.CheckAndCreateParameter(smootherName + netState, animatorController, AnimatorControllerParameterType.Float, smoothness);
             ParameterUtil.CheckAndCreateParameter(paramName + proxySuffix, animatorController, AnimatorControllerParameterType.Float);
             ParameterUtil.CheckAndCreateParameter(paramName, animatorController, AnimatorControllerParameterType.Float);
 
@@ -89,7 +89,7 @@ namespace OSCTools.OSCmooth.Util
             {
                 blendType = BlendTreeType.Simple1D,
                 hideFlags = HideFlags.HideInHierarchy,
-                blendParameter = paramName + smoothnessSuffix,
+                blendParameter = smootherName + netState,
                 name = paramName + " Root",
                 useAutomaticThresholds = false
             };

--- a/Assets/OSCmooth/Editor/OSCmoothWindow.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothWindow.cs
@@ -136,18 +136,37 @@ namespace OSCTools.OSCmooth
 
                         if (layer.isVisible)
                         {
-                            EditorGUIUtility.labelWidth = 60;
+                            EditorGUIUtility.labelWidth = 200;
 
                             layer.paramName = EditorGUILayout.TextField
                             (
                                 new GUIContent
                                 (
-                                    "",
+                                    "Parameter to smooth",
                                     "The specific float parameter that will have the smoothness layer have applied to."
                                 ),
                                 layer.paramName
                             );
+
                             EditorGUILayout.BeginHorizontal();
+
+
+                            EditorGUIUtility.labelWidth = 200;
+
+                            layer.smoothName = EditorGUILayout.TextField
+                            (
+                                new GUIContent
+                                (
+                                    "Smoother Name",
+                                    "The float smoother name"
+                                ),
+                                layer.smoothName 
+                            );
+
+
+                            EditorGUILayout.EndHorizontal();
+                            EditorGUILayout.BeginHorizontal();
+                            //GUILayout.FlexibleSpace();
 
                             EditorGUILayout.LabelField
                             (
@@ -179,7 +198,7 @@ namespace OSCTools.OSCmooth
                             (
                                 new GUIContent
                                 (
-                                    "Net",
+                                    "Remote",
                                     "How much % smoothness remote users will see when a parameter" +
                                     "changes value. Higher values represent more smoothness, and vice versa."
                                 ),


### PR DESCRIPTION
- Addition of smoother name to combine smoother floats to reduce parameters need in the animator. 
- Creates Local and Remote version of the parameter to control to the smoothing. 
- Moved generated animations to OSCmooth\Generated\Anim folder. Should keep custom smoothers separate

Known issues with the UI
- first instance of the Smoother name will be precedence for local and remote values any smoothers with the same name.  
- No overwriting of existing parameters values i.e changing the smoothness value will not change