### PR TITLE
Tiered Parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,12 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+#VRCSDK
+Assets/VRCSDK
+Assets/Resources*
+Library*
+ProjectSettings*
+Temp*
+VRC.SDKBase*
+VRC.Enums*

--- a/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
@@ -76,7 +76,7 @@ namespace OSCTools.OSCmooth.Animation
             AssetDatabase.AddObjectToAsset(basisRemoteBlendTree, AssetDatabase.GetAssetPath(animLayer.stateMachine));
 
             // Creating a '1Set' parameter that holds a value of one at all times for the Direct BlendTree
-            ParameterUtil.CheckAndCreateParameter("OSCm_BlendSet", _animatorController, AnimatorControllerParameterType.Float, 1f / (float)_parameters.Count);
+            ParameterUtil.CheckAndCreateParameter("OSCm/BlendSet", _animatorController, AnimatorControllerParameterType.Float, 1f / (float)_parameters.Count);
 
             List<ChildMotion> localChildMotion = new List<ChildMotion>();
             List<ChildMotion> remoteChildMotion = new List<ChildMotion>();
@@ -86,20 +86,20 @@ namespace OSCTools.OSCmooth.Animation
             {
                 if (p.convertToProxy)
                 {
-                    AnimUtil.RenameAllStateMachineInstancesOfBlendParameter(_animatorController, p.paramName, p.paramName + "OSCm_Proxy");
+                    AnimUtil.RenameAllStateMachineInstancesOfBlendParameter(_animatorController, p.paramName, "OSCm/Proxy/" + p.paramName + "Proxy");
                 }
 
                 localChildMotion.Add(new ChildMotion 
                 {
-                    directBlendParameter = "OSCm_BlendSet",
-                    motion = AnimUtil.CreateSmoothingBlendTree(_animatorController, animLayer.stateMachine, p.localSmoothness, p.paramName, p.flipInputOutput, (float)_parameters.Count, _animExportDirectory, "OSCm_Smoother", "OSCm_Proxy"),
+                    directBlendParameter = "OSCm/BlendSet",
+                    motion = AnimUtil.CreateSmoothingBlendTree(_animatorController, animLayer.stateMachine, p.localSmoothness, p.paramName, p.flipInputOutput, (float)_parameters.Count, _animExportDirectory, "OSCm/Local/", "Smoother", "OSCm/Proxy/", "Proxy"),
                     timeScale = 1
                 });
 
                 remoteChildMotion.Add(new ChildMotion
                 {
-                    directBlendParameter = "OSCm_BlendSet",
-                    motion = AnimUtil.CreateSmoothingBlendTree(_animatorController, animLayer.stateMachine, p.remoteSmoothness, p.paramName, p.flipInputOutput, (float)_parameters.Count, _animExportDirectory, "OSCm_SmootherRemote", "OSCm_Proxy"),
+                    directBlendParameter = "OSCm/BlendSet",
+                    motion = AnimUtil.CreateSmoothingBlendTree(_animatorController, animLayer.stateMachine, p.remoteSmoothness, p.paramName, p.flipInputOutput, (float)_parameters.Count, _animExportDirectory, "OSCm/Remote/", "Smoother", "OSCm/Proxy/", "Proxy"),
                     timeScale = 1,
                 });
             }

--- a/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
@@ -99,7 +99,7 @@ namespace OSCTools.OSCmooth.Animation
                 remoteChildMotion.Add(new ChildMotion
                 {
                     directBlendParameter = "OSCm/BlendSet",
-                    motion = AnimUtil.CreateSmoothingBlendTree(_animatorController, animLayer.stateMachine, p.remoteSmoothness, p.paramName, p.flipInputOutput, (float)_parameters.Count, _animExportDirectory, "OSCm/Remote/", "Smoother", "OSCm/Proxy/", "Proxy"),
+                    motion = AnimUtil.CreateSmoothingBlendTree(_animatorController, animLayer.stateMachine, p.remoteSmoothness, p.paramName, p.flipInputOutput, (float)_parameters.Count, _animExportDirectory, "OSCm/Remote/", "SmootherRemote", "OSCm/Proxy/", "Proxy"),
                     timeScale = 1,
                 });
             }

--- a/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothAnimationHandler.cs
@@ -86,7 +86,7 @@ namespace OSCTools.OSCmooth.Animation
             {
                 if (p.convertToProxy)
                 {
-                    AnimUtil.RenameAllStateMachineInstancesOfBlendParameter(_animatorController, p.paramName, "OSCm/Proxy/" + p.paramName + "Proxy");
+                    AnimUtil.RenameAllStateMachineInstancesOfBlendParameter(_animatorController, p.paramName, "OSCm/Proxy/" + p.paramName);
                 }
 
                 localChildMotion.Add(new ChildMotion 

--- a/Assets/OSCmooth/Editor/OSCmoothUtil.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothUtil.cs
@@ -83,7 +83,7 @@ namespace OSCTools.OSCmooth.Util
                 defaultWeight = 1f
             };
 
-            CleanAnimatorBlendTreeBloat(animatorController,  "OSCm/");
+            CleanAnimatorBlendTreeBloat(animatorController,  "OSCm_");
 
             // Store Layer into Animator Controller, as creating a Layer object is not serialized unless we store it inside an asset.
             if (AssetDatabase.GetAssetPath(animatorController) != string.Empty)

--- a/Assets/OSCmooth/Editor/OSCmoothUtil.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothUtil.cs
@@ -109,8 +109,8 @@ namespace OSCTools.OSCmooth.Util
             AnimationCurve _curvesInit = new AnimationCurve(new Keyframe(0.0f, initThreshold));
             AnimationCurve _curvesFinal = new AnimationCurve(new Keyframe(0.0f, finalThreshold));
 
-            _animationClipInit.SetCurve("", typeof(Animator), driveBase ? paramName : proxyPrefix + paramName + proxySuffix, _curvesInit);
-            _animationClipFinal.SetCurve("", typeof(Animator), driveBase ? paramName : proxyPrefix + paramName + proxySuffix, _curvesFinal);
+            _animationClipInit.SetCurve("", typeof(Animator), driveBase ? paramName : proxyPrefix + paramName, _curvesInit);
+            _animationClipFinal.SetCurve("", typeof(Animator), driveBase ? paramName : proxyPrefix + paramName, _curvesFinal);
 
             if (!Directory.Exists(directory))
             {
@@ -164,8 +164,8 @@ namespace OSCTools.OSCmooth.Util
 
         public static BlendTree CreateSmoothingBlendTree(AnimatorController animatorController, AnimatorStateMachine stateMachine, float smoothness, string paramName, bool driveBase, float range, string directory, string smoothnessPrefix = "OSCm/", string smoothnessSuffix = "Smoother", string proxyPrefix = "OSCm/", string proxySuffix = "Proxy")
         {
-            AnimatorControllerParameter smootherParam = ParameterUtil.CheckAndCreateParameter(smoothnessPrefix + paramName + smoothnessSuffix, animatorController, AnimatorControllerParameterType.Float, smoothness);
-            ParameterUtil.CheckAndCreateParameter(proxyPrefix + paramName + proxySuffix, animatorController, AnimatorControllerParameterType.Float);
+            AnimatorControllerParameter smootherParam = ParameterUtil.CheckAndCreateParameter(smoothnessPrefix + paramName + "Smoother", animatorController, AnimatorControllerParameterType.Float, smoothness);
+            ParameterUtil.CheckAndCreateParameter(proxyPrefix + paramName, animatorController, AnimatorControllerParameterType.Float);
             ParameterUtil.CheckAndCreateParameter(paramName, animatorController, AnimatorControllerParameterType.Float);
 
             // Creating 3 blend trees to create the feedback loop
@@ -173,7 +173,7 @@ namespace OSCTools.OSCmooth.Util
             {
                 blendType = BlendTreeType.Simple1D,
                 hideFlags = HideFlags.HideInHierarchy,
-                blendParameter = smoothnessPrefix + paramName + smoothnessSuffix,
+                blendParameter = smoothnessPrefix + paramName + "Smoother",
                 name = "OSCm_" + paramName + " Root",
                 useAutomaticThresholds = false
             };
@@ -181,7 +181,7 @@ namespace OSCTools.OSCmooth.Util
             {
                 blendType = BlendTreeType.Simple1D,
                 hideFlags = HideFlags.HideInHierarchy,
-                blendParameter = driveBase ? paramName + proxySuffix : paramName,
+                blendParameter = driveBase ? proxyPrefix + paramName : paramName,
                 name = "OSCm_Input",
                 useAutomaticThresholds = false
             };
@@ -189,7 +189,7 @@ namespace OSCTools.OSCmooth.Util
             {
                 blendType = BlendTreeType.Simple1D,
                 hideFlags = HideFlags.HideInHierarchy,
-                blendParameter = driveBase ? paramName: proxyPrefix + paramName + proxySuffix,
+                blendParameter = driveBase ? paramName: proxyPrefix + paramName,
                 name = "OSCm_Driver",
                 useAutomaticThresholds = false
             };

--- a/Assets/OSCmooth/Editor/OSCmoothWindow.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothWindow.cs
@@ -30,7 +30,7 @@ namespace OSCTools.OSCmooth
 
         readonly private string[] oscmBlacklist = new string[]
         {
-            "OSCm_", "IsLocal", "Smooth", "Proxy", "_Float", "_Normalizer", "_FTI"
+            "OSCm/", "IsLocal", "Smooth", "Proxy", "_Float", "_Normalizer", "_FTI"
         };
 
         [MenuItem("Tools/OSCmooth")]


### PR DESCRIPTION
Adding OSCmooth to avatar parameters can get overwhelming when trying to select parameters for animations. I am making pull request to change how the naming of the parameters to take advantage of the the forward slash to act as filing structure in Unity.

![image](https://user-images.githubusercontent.com/58948489/200074048-e78d28ae-f8ce-4af3-8d3d-9be7bc7de75c.png)

Code I am not very certain about is the blacklist on OSCmoothWindow and CleanAnimatorBlendTreeBloat on OSCmoothUtil
