### PR TITLE
Fix write defaults ON breaking in VRC stations

### DIFF
--- a/Assets/OSCmooth/Editor/OSCmoothUtil.cs
+++ b/Assets/OSCmooth/Editor/OSCmoothUtil.cs
@@ -62,6 +62,18 @@ namespace OSCTools.OSCmooth.Util
             }
         }
 
+        public static void RemoveAnimLayerInController(string layerName, AnimatorController animatorController)
+        {
+            for (int i = 0; i < animatorController.layers.Length; i++)
+            {
+                if (animatorController.layers[i].name == layerName)
+                {
+                    animatorController.RemoveLayer(i);
+                }
+            }
+
+        }
+
         public static AnimatorControllerLayer CreateAnimLayerInController(string layerName, AnimatorController animatorController)
         {
             for (int i = 0; i < animatorController.layers.Length; i++)


### PR DESCRIPTION
Write defaults ON has issues with direct blend trees with write default off version. This caused when sitting in station, changing animation to -1 to 1 scale and OSCm/BlendSet to 1 fixes the issue.