### PR TITLE
Add Editor.SetDirty to force unity to save changes on the file.

### DIFF
--- a/Packages/dev.azmidi.oscmooth/Script/Editor/OSCmoothParameterUtil.cs
+++ b/Packages/dev.azmidi.oscmooth/Script/Editor/OSCmoothParameterUtil.cs
@@ -93,6 +93,8 @@ namespace OSCmooth.Util
             _proxyExpressions.parameters = BakeAndClearParameters(_vrcParameters);
 
             avatarDescriptor.expressionParameters = _proxyExpressions;
+            
+            EditorUtility.SetDirty(_proxyExpressions);
             AssetDatabase.SaveAssets();
             return true;
         }


### PR DESCRIPTION
Added EditorUtility.SetDirty on _proxyExpressions to fix weird issue of Unity keeping the changes only in memory, reverting changes when closing unity or renaming the file. Setting the file as dirty force unity to save the file properly.